### PR TITLE
Add Attachment Upload Support

### DIFF
--- a/lib/wrike.js
+++ b/lib/wrike.js
@@ -105,12 +105,19 @@ Wrike.prototype.__request = function(method, path, params, callback) {
 
   // Pass form data if post
   if (method === 'post') {
-    var formKey = 'form';
+      if (params.file) {
+          options.headers = {
+              'X-File-Name': params.file.name
+          };
+          options.body = params.file.content;
+      } else {
+          var formKey = 'form';
 
-    if (typeof params.media !== 'undefined') {
-      formKey = 'formData';
-    }
-    options[formKey] = params;
+          if (typeof params.media !== 'undefined') {
+              formKey = 'formData';
+          }
+          options[formKey] = params;
+      }
   }
 
   // Pass form data if put


### PR DESCRIPTION
Usage:
```JS
await wrike.post(`/tasks/${newTaskID}/attachments`, {
   file: {
      content: attachment.content, //Should be buffer
      name: attachment.fileName,
    }
});
```